### PR TITLE
useStripe

### DIFF
--- a/src/components/Elements.js
+++ b/src/components/Elements.js
@@ -135,7 +135,7 @@ export const useElements = (): ElementsShape | null => {
 };
 
 export const useStripe = (): StripeShape | null => {
-  const ctx = useElementsContextWithUseCase('calls useElements()');
+  const ctx = useElementsContextWithUseCase('calls useStripe()');
 
   return ctx && ctx.stripe;
 };

--- a/src/components/Elements.js
+++ b/src/components/Elements.js
@@ -1,11 +1,10 @@
 // @flow
 /* eslint-disable react/forbid-prop-types, react/require-default-props */
-import * as React from 'react';
+import React, {useContext, useMemo, useState} from 'react';
 import PropTypes from 'prop-types';
 
 import isEqual from '../utils/isEqual';
-
-const {useContext, useEffect, useRef, useState} = React;
+import usePrevious from '../utils/usePrevious';
 
 type ElementContext =
   | {|
@@ -18,51 +17,13 @@ type ElementContext =
 
 const ElementsContext = React.createContext<?ElementContext>();
 
-type Props = {|
-  stripe: ?StripeShape,
-  options?: MixedObject,
-  children?: any,
-|};
-
-const validateStripe = (maybeStripe: $NonMaybeType<mixed>) => {
-  if (
-    typeof maybeStripe === 'object' &&
-    maybeStripe.elements &&
-    maybeStripe.createSource &&
-    maybeStripe.createToken &&
-    maybeStripe.createPaymentMethod
-  ) {
-    return;
-  }
-
-  throw new Error(
-    'Invalid prop `stripe` supplied to `Elements`. Please pass a valid Stripe object. ' +
-      'You can obtain a Stripe object by calling `window.Stripe(...)` with your publishable key.'
-  );
-};
-
-const usePrevious = (value) => {
-  const ref = useRef();
-
-  useEffect(() => {
-    ref.current = value;
-  }, [value]);
-
-  return ref.current;
-};
-
-const createElementsContext = (
-  stripe: ?StripeShape,
+export const createElementsContext = (
+  stripe: null | StripeShape,
   options: ?MixedObject
 ): ElementContext => {
-  if (stripe == null) {
+  if (stripe === null) {
     return {tag: 'loading'};
   }
-
-  // We are using types to enforce the `stripe` prop in this lib,
-  // but in a real integration, `stripe` could be anything, so we need
-  // to do some sanity validation to prevent type errors.
-  validateStripe(stripe);
 
   return {
     tag: 'ready',
@@ -70,43 +31,7 @@ const createElementsContext = (
   };
 };
 
-export const Elements = ({stripe, options, children}: Props) => {
-  const [elements, setElements] = useState(() =>
-    createElementsContext(stripe, options)
-  );
-
-  if (stripe != null && elements.tag === 'loading') {
-    setElements(createElementsContext(stripe, options));
-  }
-
-  const prevStripe = usePrevious(stripe);
-  if (prevStripe != null && prevStripe !== stripe) {
-    console.warn(
-      'Unsupported prop change on Elements: You cannot change the `stripe` prop after setting it.'
-    );
-  }
-
-  const prevOptions = usePrevious(options);
-  if (prevStripe != null && !isEqual(prevOptions, options)) {
-    console.warn(
-      'Unsupported prop change on Elements: You cannot change the `options` prop after setting the `stripe` prop.'
-    );
-  }
-
-  return (
-    <ElementsContext.Provider value={elements}>
-      {children}
-    </ElementsContext.Provider>
-  );
-};
-
-Elements.propTypes = {
-  stripe: PropTypes.any,
-  children: PropTypes.any,
-  options: PropTypes.object,
-};
-
-const parseElementsContext = (
+export const parseElementsContext = (
   ctx: ?ElementContext,
   useCase: string
 ): null | ElementsShape => {
@@ -121,6 +46,77 @@ const parseElementsContext = (
   }
 
   return ctx.elements;
+};
+
+// We are using types to enforce the `stripe` prop in this lib,
+// but in a real integration `stripe` could be anything, so we need
+// to do some sanity validation to prevent type errors.
+const validateStripe = (maybeStripe: mixed): StripeShape | null => {
+  if (maybeStripe === null) {
+    return maybeStripe;
+  }
+
+  if (
+    typeof maybeStripe === 'object' &&
+    maybeStripe.elements &&
+    maybeStripe.createSource &&
+    maybeStripe.createToken &&
+    maybeStripe.createPaymentMethod
+  ) {
+    return ((maybeStripe: any): StripeShape);
+  }
+
+  throw new Error(
+    'Invalid prop `stripe` supplied to `Elements`. Please pass a valid Stripe object or null. ' +
+      'You can obtain a Stripe object by calling `window.Stripe(...)` with your publishable key.'
+  );
+};
+
+type Props = {|
+  stripe: StripeShape | null,
+  options?: MixedObject,
+  children?: any,
+|};
+
+export const Elements = ({stripe: rawStripe, options, children}: Props) => {
+  // We are using types to enforce the `stripe` prop in this lib,
+  // but in a real integration, `stripe` could be anything, so we need
+  // to do some sanity validation to prevent type errors.
+  const stripe = useMemo(() => validateStripe(rawStripe), [rawStripe]);
+
+  const [elements, setElements] = useState(() =>
+    createElementsContext(stripe, options)
+  );
+
+  if (stripe !== null && elements.tag === 'loading') {
+    setElements(createElementsContext(stripe, options));
+  }
+
+  const prevStripe = usePrevious(stripe);
+  if (prevStripe != null && prevStripe !== stripe) {
+    console.warn(
+      'Unsupported prop change on Elements: You cannot change the `stripe` prop after setting it.'
+    );
+  }
+
+  const prevOptions = usePrevious(options);
+  if (prevStripe !== null && !isEqual(prevOptions, options)) {
+    console.warn(
+      'Unsupported prop change on Elements: You cannot change the `options` prop after setting the `stripe` prop.'
+    );
+  }
+
+  return (
+    <ElementsContext.Provider value={elements}>
+      {children}
+    </ElementsContext.Provider>
+  );
+};
+
+Elements.propTypes = {
+  stripe: PropTypes.any,
+  children: PropTypes.node,
+  options: PropTypes.object,
 };
 
 export const useElementsWithUseCase = (useCaseMessage: string) => {
@@ -141,5 +137,5 @@ export const ElementsConsumer = ({
 };
 
 ElementsConsumer.propTypes = {
-  children: PropTypes.func,
+  children: PropTypes.func.isRequired,
 };

--- a/src/components/Elements.test.js
+++ b/src/components/Elements.test.js
@@ -65,19 +65,20 @@ describe('Elements', () => {
     expect(wrapper.find(TestComponent).prop('elements')).toBe(mockElements);
   });
 
-  it('allows a transition from undefined to a valid stripe object', () => {
-    const wrapper = mount(
-      <Elements stripe={undefined}>
-        <InjectedTestComponent />
-      </Elements>
-    );
+  it('errors when props.stripe is `undefined`', () => {
+    // Prevent the console.errors to keep the test output clean
+    jest.spyOn(console, 'error');
+    console.error.mockImplementation(() => {});
 
-    expect(wrapper.find(TestComponent).prop('elements')).toBe(null);
-    wrapper.setProps({
-      stripe,
-    });
-    wrapper.update();
-    expect(wrapper.find(TestComponent).prop('elements')).toBe(mockElements);
+    expect(() =>
+      mount(
+        <Elements>
+          <InjectedTestComponent />
+        </Elements>
+      )
+    ).toThrow('Invalid prop `stripe` supplied to `Elements`.');
+
+    console.error.mockRestore();
   });
 
   it('errors when props.stripe is `false`', () => {

--- a/src/components/Elements.test.js
+++ b/src/components/Elements.test.js
@@ -7,8 +7,12 @@ import {mockStripe} from '../../test/mocks';
 const TestComponent = () => <div>test</div>;
 const InjectedTestComponent = () => {
   const elements = useElements();
+  return <TestComponent elements={elements} />;
+};
+
+const StripeInjectedTestComponent = () => {
   const stripe = useStripe();
-  return <TestComponent elements={elements} stripe={stripe} />;
+  return <TestComponent stripe={stripe} />;
 };
 
 describe('Elements', () => {
@@ -31,16 +35,6 @@ describe('Elements', () => {
     expect(wrapper.find(TestComponent).prop('elements')).toBe(mockElements);
   });
 
-  it('injects stripe with the useStripe hook', () => {
-    const wrapper = mount(
-      <Elements stripe={stripe}>
-        <InjectedTestComponent />
-      </Elements>
-    );
-
-    expect(wrapper.find(TestComponent).prop('stripe')).toBe(stripe);
-  });
-
   it('only creates elements once', () => {
     mount(
       <Elements stripe={stripe}>
@@ -49,6 +43,16 @@ describe('Elements', () => {
     );
 
     expect(stripe.elements.mock.calls).toHaveLength(1);
+  });
+
+  it('injects stripe with the useStripe hook', () => {
+    const wrapper = mount(
+      <Elements stripe={stripe}>
+        <StripeInjectedTestComponent />
+      </Elements>
+    );
+
+    expect(wrapper.find(TestComponent).prop('stripe')).toBe(stripe);
   });
 
   it('provides elements and stripe with the ElementsConsumer component', () => {
@@ -185,6 +189,16 @@ describe('Elements', () => {
     console.error.mockImplementation(() => {});
     expect(() => mount(<InjectedTestComponent />)).toThrow(
       'Could not find Elements context; You need to wrap the part of your app that calls useElements() in an <Elements> provider.'
+    );
+    console.error.mockRestore();
+  });
+
+  it('throws when trying to call useStripe outside of Elements context', () => {
+    // Prevent the console.errors to keep the test output clean
+    jest.spyOn(console, 'error');
+    console.error.mockImplementation(() => {});
+    expect(() => mount(<StripeInjectedTestComponent />)).toThrow(
+      'Could not find Elements context; You need to wrap the part of your app that calls useStripe() in an <Elements> provider.'
     );
     console.error.mockRestore();
   });

--- a/src/components/Elements.test.js
+++ b/src/components/Elements.test.js
@@ -1,13 +1,14 @@
 // @noflow
 import React from 'react';
 import {mount} from 'enzyme';
-import {Elements, useElements, ElementsConsumer} from './Elements';
+import {Elements, useElements, useStripe, ElementsConsumer} from './Elements';
 import {mockStripe} from '../../test/mocks';
 
 const TestComponent = () => <div>test</div>;
 const InjectedTestComponent = () => {
   const elements = useElements();
-  return <TestComponent elements={elements} />;
+  const stripe = useStripe();
+  return <TestComponent elements={elements} stripe={stripe} />;
 };
 
 describe('Elements', () => {
@@ -30,6 +31,16 @@ describe('Elements', () => {
     expect(wrapper.find(TestComponent).prop('elements')).toBe(mockElements);
   });
 
+  it('injects stripe with the useStripe hook', () => {
+    const wrapper = mount(
+      <Elements stripe={stripe}>
+        <InjectedTestComponent />
+      </Elements>
+    );
+
+    expect(wrapper.find(TestComponent).prop('stripe')).toBe(stripe);
+  });
+
   it('only creates elements once', () => {
     mount(
       <Elements stripe={stripe}>
@@ -40,16 +51,19 @@ describe('Elements', () => {
     expect(stripe.elements.mock.calls).toHaveLength(1);
   });
 
-  it('provides elements with the ElementsConsumer component', () => {
+  it('provides elements and stripe with the ElementsConsumer component', () => {
     const wrapper = mount(
       <Elements stripe={stripe}>
         <ElementsConsumer>
-          {(elements) => <TestComponent elements={elements} />}
+          {(ctx) => (
+            <TestComponent elements={ctx.elements} stripe={ctx.stripe} />
+          )}
         </ElementsConsumer>
       </Elements>
     );
 
     expect(wrapper.find(TestComponent).prop('elements')).toBe(mockElements);
+    expect(wrapper.find(TestComponent).prop('stripe')).toBe(stripe);
   });
 
   it('allows a transition from null to a valid stripe object', () => {
@@ -170,7 +184,7 @@ describe('Elements', () => {
     jest.spyOn(console, 'error');
     console.error.mockImplementation(() => {});
     expect(() => mount(<InjectedTestComponent />)).toThrow(
-      'Could not find elements context; You need to wrap the part of your app that is calling useElements() in an <Elements> provider.'
+      'Could not find Elements context; You need to wrap the part of your app that calls useElements() in an <Elements> provider.'
     );
     console.error.mockRestore();
   });
@@ -186,7 +200,7 @@ describe('Elements', () => {
     );
 
     expect(() => mount(<WithAConsumer />)).toThrow(
-      'Could not find elements context; You need to wrap the part of your app that is mounting <ElementsConsumer> in an <Elements> provider.'
+      'Could not find Elements context; You need to wrap the part of your app that mounts <ElementsConsumer> in an <Elements> provider.'
     );
     console.error.mockRestore();
   });

--- a/src/components/createElementComponent.js
+++ b/src/components/createElementComponent.js
@@ -2,7 +2,7 @@
 /* eslint-disable react/forbid-prop-types */
 import React, {useRef, useEffect, useLayoutEffect} from 'react';
 import PropTypes from 'prop-types';
-import {useElementsWithUseCase} from './Elements';
+import {useElementsContextWithUseCase} from './Elements';
 import isEqual from '../utils/isEqual';
 
 type Props = {
@@ -57,7 +57,7 @@ const createElementComponent = (type: string) => {
       onClick,
     } = props;
 
-    const elements = useElementsWithUseCase(`mounting <${displayName}>`);
+    const ctx = useElementsContextWithUseCase(`mounts <${displayName}>`);
     const elementRef = useRef();
     const domNode = useRef();
 
@@ -70,10 +70,10 @@ const createElementComponent = (type: string) => {
     useLayoutEffect(() => {
       if (
         elementRef.current == null &&
-        elements != null &&
+        ctx != null &&
         domNode.current != null
       ) {
-        const element = elements.create(type, options);
+        const element = ctx.elements.create(type, options);
         elementRef.current = element;
         element.mount(domNode.current);
         element.on('ready', () => callOnReady(element));

--- a/src/components/createElementComponent.test.js
+++ b/src/components/createElementComponent.test.js
@@ -112,7 +112,7 @@ describe('createElementComponent', () => {
     jest.spyOn(console, 'error');
     console.error.mockImplementation(() => {});
     expect(() => mount(<CardElement />)).toThrow(
-      'Could not find elements context; You need to wrap the part of your app that is mounting <CardElement> in an <Elements> provider.'
+      'Could not find Elements context; You need to wrap the part of your app that mounts <CardElement> in an <Elements> provider.'
     );
     console.error.mockRestore();
   });

--- a/src/utils/usePrevious.js
+++ b/src/utils/usePrevious.js
@@ -1,0 +1,14 @@
+// @flow
+import {useRef, useEffect} from 'react';
+
+const usePrevious = <T>(value: T): T => {
+  const ref = useRef(value);
+
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+
+  return ref.current;
+};
+
+export default usePrevious;

--- a/src/utils/usePrevious.test.js
+++ b/src/utils/usePrevious.test.js
@@ -1,0 +1,27 @@
+// @noflow
+import React from 'react';
+import {mount} from 'enzyme';
+import usePrevious from './usePrevious';
+
+const TestComponent = ({foo}) => {
+  const lastFoo = usePrevious(foo);
+  return <div>{lastFoo}</div>;
+};
+
+describe('usePrevious', () => {
+  it('returns the initial value if it has not yet been changed', () => {
+    const wrapper = mount(<TestComponent foo="foo" />);
+
+    expect(wrapper.find('div').text()).toEqual('foo');
+  });
+
+  it('returns the previous value after the it has been changed', () => {
+    const wrapper = mount(<TestComponent foo="foo" />);
+    wrapper.setProps({foo: 'bar'});
+    expect(wrapper.find('div').text()).toEqual('foo');
+    wrapper.setProps({foo: 'baz'});
+    expect(wrapper.find('div').text()).toEqual('bar');
+    wrapper.setProps({foo: 'buz'});
+    expect(wrapper.find('div').text()).toEqual('baz');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1666,24 +1666,6 @@
     "@svgr/plugin-svgo" "^4.3.1"
     loader-utils "^1.2.3"
 
-"@textlint/ast-node-types@^4.0.3":
-  version "4.2.5"
-  resolved "https://registry.yarnpkg.com/@textlint/ast-node-types/-/ast-node-types-4.2.5.tgz#ae13981bc8711c98313a6ac1c361194d6bf2d39b"
-  integrity sha512-+rEx4jLOeZpUcdvll7jEg/7hNbwYvHWFy4IGW/tk2JdbyB3SJVyIP6arAwzTH/sp/pO9jftfyZnRj4//sLbLvQ==
-
-"@textlint/markdown-to-ast@~6.0.9":
-  version "6.0.9"
-  resolved "https://registry.yarnpkg.com/@textlint/markdown-to-ast/-/markdown-to-ast-6.0.9.tgz#e7c89e5ad15d17dcd8e5a62758358936827658fa"
-  integrity sha512-hfAWBvTeUGh5t5kTn2U3uP3qOSM1BSrxzl1jF3nn0ywfZXpRBZr5yRjXnl4DzIYawCtZOshmRi/tI3/x4TE1jQ==
-  dependencies:
-    "@textlint/ast-node-types" "^4.0.3"
-    debug "^2.1.3"
-    remark-frontmatter "^1.2.0"
-    remark-parse "^5.0.0"
-    structured-source "^3.0.2"
-    traverse "^0.6.6"
-    unified "^6.1.6"
-
 "@types/babel__core@^7.1.0":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.3.tgz#e441ea7df63cd080dfcd02ab199e6d16a735fc30"
@@ -2118,13 +2100,6 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
-
-anchor-markdown-header@^0.5.5:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/anchor-markdown-header/-/anchor-markdown-header-0.5.7.tgz#045063d76e6a1f9cd327a57a0126aa0fdec371a7"
-  integrity sha1-BFBj125qH5zTJ6V6ASaqD97Dcac=
-  dependencies:
-    emoji-regex "~6.1.0"
 
 ansi-align@^3.0.0:
   version "3.0.0"
@@ -2796,11 +2771,6 @@ babel-runtime@^6.18.0, babel-runtime@^6.26.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
-bail@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.4.tgz#7181b66d508aa3055d3f6c13f0a0c720641dde9b"
-  integrity sha512-S8vuDB4w6YpRhICUDET3guPlQpaJl7od94tpZ0Fvnyp+MKW/HyDTcRDck+29C9g+d/qQHnddRH3+94kZdrW0Ww==
-
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -2876,11 +2846,6 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
-
-boundary@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/boundary/-/boundary-1.0.1.tgz#4d67dc2602c0cc16dd9bce7ebf87e948290f5812"
-  integrity sha1-TWfcJgLAzBbdm85+v4fpSCkPWBI=
 
 boxen@^3.0.0:
   version "3.2.0"
@@ -3360,11 +3325,6 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-collapse-white-space@^1.0.2:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.5.tgz#c2495b699ab1ed380d29a1091e01063e75dbbe3a"
-  integrity sha512-703bOOmytCYAX9cXYqoikYIx6twmFCXsnzRQheBcTG3nzKYBR4P/+wkYeH+Mvj7qUz8zZDtdyzbxfnEi/kYzRQ==
-
 collection-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
@@ -3771,7 +3731,7 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.9:
+debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -3931,18 +3891,6 @@ discontinuous-range@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
   integrity sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=
-
-doctoc@^1.3.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/doctoc/-/doctoc-1.4.0.tgz#3115aa61d0a92f0abb0672036918ea904f5b9e02"
-  integrity sha512-8IAq3KdMkxhXCUF+xdZxdJxwuz8N2j25sMgqiu4U4JWluN9tRKMlAalxGASszQjlZaBprdD2YfXpL3VPWUD4eg==
-  dependencies:
-    "@textlint/markdown-to-ast" "~6.0.9"
-    anchor-markdown-header "^0.5.5"
-    htmlparser2 "~3.9.2"
-    minimist "~1.2.0"
-    underscore "~1.8.3"
-    update-section "^0.3.0"
 
 doctrine@1.5.0:
   version "1.5.0"
@@ -4135,11 +4083,6 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
-
-emoji-regex@~6.1.0:
-  version "6.1.3"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.1.3.tgz#ec79a3969b02d2ecf2b72254279bf99bc7a83932"
-  integrity sha1-7HmjlpsC0uzytyJUJ5v5m8eoOTI=
 
 emojis-list@^2.0.0:
   version "2.1.0"
@@ -4701,7 +4644,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.0, extend@~3.0.2:
+extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -4771,7 +4714,7 @@ fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-fault@^1.0.1, fault@^1.0.2:
+fault@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/fault/-/fault-1.0.3.tgz#4da88cf979b6b792b4e13c7ec836767725170b7e"
   integrity sha512-sfFuP4X0hzrbGKjAUNXYvNqsZ5F6ohx/dZ9I0KQud/aiZNwg263r5L9yGB0clvXHCkzXh5W3t7RSHchggYIFmA==
@@ -5476,18 +5419,6 @@ htmlparser2@^3.3.0, htmlparser2@^3.9.1:
     inherits "^2.0.1"
     readable-stream "^3.1.1"
 
-htmlparser2@~3.9.2:
-  version "3.9.2"
-  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
-  integrity sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=
-  dependencies:
-    domelementtype "^1.3.0"
-    domhandler "^2.3.0"
-    domutils "^1.5.1"
-    entities "^1.1.1"
-    inherits "^2.0.1"
-    readable-stream "^2.0.2"
-
 http-errors@1.7.2:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.2.tgz#4f5029cf13239f31036e5b2e55292bcfbcc85c8f"
@@ -5779,7 +5710,7 @@ is-boolean-object@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.0.0.tgz#98f8b28030684219a95f375cfbd88ce3405dff93"
   integrity sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M=
 
-is-buffer@^1.0.2, is-buffer@^1.1.4, is-buffer@^1.1.5:
+is-buffer@^1.0.2, is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -5936,7 +5867,7 @@ is-object@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
   integrity sha1-iVJojF7C/9awPsyF52ngKQMINHA=
 
-is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
+is-plain-obj@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
@@ -6006,11 +5937,6 @@ is-typedarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
-is-whitespace-character@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz#b3ad9546d916d7d3ffa78204bca0c26b56257fac"
-  integrity sha512-SNPgMLz9JzPccD3nPctcj8sZlX9DAMJSKH8bP7Z6bohCwuNgX8xbWr1eTAYXX9Vpi/aSn8Y1akL9WgM3t43YNQ==
-
 is-window@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-window/-/is-window-1.0.2.tgz#2c896ca53db97de45d3c33133a65d8c9f563480d"
@@ -6020,11 +5946,6 @@ is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
-
-is-word-character@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/is-word-character/-/is-word-character-1.0.3.tgz#264d15541cbad0ba833d3992c34e6b40873b08aa"
-  integrity sha512-0wfcrFgOOOBdgRNT9H33xe6Zi6yhX/uoc4U8NBZGeQQB0ctU1dnlNTyL9JM2646bHDTpsDm1Brb3VPoCIMrd/A==
 
 is-wsl@^1.1.0:
   version "1.1.0"
@@ -6886,11 +6807,6 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-markdown-escapes@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.3.tgz#6155e10416efaafab665d466ce598216375195f5"
-  integrity sha512-XUi5HJhhV5R74k8/0H2oCbCiYf/u4cO/rX8tnGkRvrqhsr5BRNU6Mg0yt/8UIx1iIS8220BNJsDb7XnILhLepw==
-
 markdown-to-jsx@^6.9.1, markdown-to-jsx@^6.9.3:
   version "6.10.3"
   resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-6.10.3.tgz#7f0946684acd321125ff2de7fd258a9b9c7c40b7"
@@ -7073,7 +6989,7 @@ minimist@0.0.8:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
-minimist@^1.1.1, minimist@^1.2.0, minimist@~1.2.0:
+minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
@@ -7721,7 +7637,7 @@ parse-asn1@^5.0.0:
     pbkdf2 "^3.0.3"
     safe-buffer "^5.1.1"
 
-parse-entities@^1.1.0, parse-entities@^1.1.2:
+parse-entities@^1.1.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.2.2.tgz#c31bf0f653b6661354f8973559cb86dd1d5edf50"
   integrity sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==
@@ -8513,16 +8429,6 @@ react-test-renderer@^16.0.0-0:
     react-is "^16.8.6"
     scheduler "^0.17.0"
 
-react-test-renderer@~16.8.0:
-  version "16.8.6"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.8.6.tgz#188d8029b8c39c786f998aa3efd3ffe7642d5ba1"
-  integrity sha512-H2srzU5IWYT6cZXof6AhUcx/wEyJddQ8l7cLM/F7gDXYyPr4oq+vCIxJYXVGhId1J706sqziAjuOEjyNkfgoEw==
-  dependencies:
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    react-is "^16.8.6"
-    scheduler "^0.13.6"
-
 react-textarea-autosize@^7.1.0:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-7.1.2.tgz#70fdb333ef86bcca72717e25e623e90c336e2cda"
@@ -8753,35 +8659,6 @@ relateurl@^0.2.7:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
 
-remark-frontmatter@^1.2.0:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/remark-frontmatter/-/remark-frontmatter-1.3.2.tgz#91d9684319cd1b96cc3d9d901f10a978f39c752d"
-  integrity sha512-2eayxITZ8rezsXdgcXnYB3iLivohm2V/ZT4Ne8uhua6A4pk6GdLE2ZzJnbnINtD1HRLaTdB7RwF9sgUbMptJZA==
-  dependencies:
-    fault "^1.0.1"
-    xtend "^4.0.1"
-
-remark-parse@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-5.0.0.tgz#4c077f9e499044d1d5c13f80d7a98cf7b9285d95"
-  integrity sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==
-  dependencies:
-    collapse-white-space "^1.0.2"
-    is-alphabetical "^1.0.0"
-    is-decimal "^1.0.0"
-    is-whitespace-character "^1.0.0"
-    is-word-character "^1.0.0"
-    markdown-escapes "^1.0.0"
-    parse-entities "^1.1.0"
-    repeat-string "^1.5.4"
-    state-toggle "^1.0.0"
-    trim "0.0.1"
-    trim-trailing-lines "^1.0.0"
-    unherit "^1.0.4"
-    unist-util-remove-position "^1.0.0"
-    vfile-location "^2.0.0"
-    xtend "^4.0.1"
-
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -8803,15 +8680,10 @@ repeat-element@^1.1.2:
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
   integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
 
-repeat-string@^1.5.4, repeat-string@^1.6.1:
+repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
-
-replace-ext@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
-  integrity sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=
 
 request-promise-core@1.1.3:
   version "1.1.3"
@@ -9502,11 +9374,6 @@ stack-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
   integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
 
-state-toggle@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.2.tgz#75e93a61944116b4959d665c8db2d243631d6ddc"
-  integrity sha512-8LpelPGR0qQM4PnfLiplOQNJcIN1/r2Gy0xKB2zKnIW2YzPMt2sR4I/+gtPjhN7Svh9kw+zqEg2SFwpBO9iNiw==
-
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -9726,13 +9593,6 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
-structured-source@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/structured-source/-/structured-source-3.0.2.tgz#dd802425e0f53dc4a6e7aca3752901a1ccda7af5"
-  integrity sha1-3YAkJeD1PcSm56yjdSkBoczaevU=
-  dependencies:
-    boundary "^1.0.1"
-
 style-loader@^0.23.1:
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.23.1.tgz#cb9154606f3e771ab6c4ab637026a1049174d925"
@@ -9861,7 +9721,16 @@ terser-webpack-plugin@^1.2.4, terser-webpack-plugin@^1.4.1:
     webpack-sources "^1.4.0"
     worker-farm "^1.7.0"
 
-terser@^4.1.0, terser@^4.1.2, terser@^4.3.9:
+terser@^4.1.0:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.4.2.tgz#448fffad0245f4c8a277ce89788b458bfd7706e8"
+  integrity sha512-Uufrsvhj9O1ikwgITGsZ5EZS6qPokUOkCegS7fYOdGTv+OA90vndUbU6PEjr5ePqHfNUbGyMO7xyIZv2MhsALQ==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.6.1"
+    source-map-support "~0.5.12"
+
+terser@^4.1.2, terser@^4.3.9:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.4.0.tgz#22c46b4817cf4c9565434bfe6ad47336af259ac3"
   integrity sha512-oDG16n2WKm27JO8h4y/w3iqBGAOSCtq7k8dRmrn4Wf9NouL0b2WpMHGChFGZq4nFAQy1FsNJrVQHfurXOSTmOA==
@@ -10000,26 +9869,6 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
-traverse@^0.6.6:
-  version "0.6.6"
-  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
-  integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
-
-trim-trailing-lines@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz#d2f1e153161152e9f02fabc670fb40bec2ea2e3a"
-  integrity sha512-MUjYItdrqqj2zpcHFTkMa9WAv4JHTI6gnRQGPFLrt5L9a6tRMiDnIqYl8JBvu2d2Tc3lWJKQwlGCp0K8AvCM+Q==
-
-trim@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
-  integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
-
-trough@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.4.tgz#3b52b1f13924f460c3fbfd0df69b587dbcbc762e"
-  integrity sha512-tdzBRDGWcI1OpPVmChbdSKhvSVurznZ8X36AYURAcl+0o2ldlCY2XPzyXNNxwJwwyIU+rIglTCG4kxtNKBQH7Q==
-
 ts-pnp@^1.1.2:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.5.tgz#840e0739c89fce5f3abd9037bb091dbff16d9dec"
@@ -10095,23 +9944,10 @@ uglify-js@^3.1.4:
     commander "~2.20.3"
     source-map "~0.6.1"
 
-underscore@~1.8.3:
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
-  integrity sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=
-
 unfetch@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.1.0.tgz#6ec2dd0de887e58a4dee83a050ded80ffc4137db"
   integrity sha512-crP/n3eAPUJxZXM9T80/yv0YhkTEx2K1D3h7D1AJM6fzsWZrxdyRuLN0JH/dkZh1LNH8LxCnBzoPFCPbb2iGpg==
-
-unherit@^1.0.4:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.2.tgz#14f1f397253ee4ec95cec167762e77df83678449"
-  integrity sha512-W3tMnpaMG7ZY6xe/moK04U9fBhi6wEiCYHUW5Mop/wQHf12+79EQGwxYejNdhEz2mkqkBlGwm7pxmgBKMVUj0w==
-  dependencies:
-    inherits "^2.0.1"
-    xtend "^4.0.1"
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
@@ -10135,18 +9971,6 @@ unicode-property-aliases-ecmascript@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz#a9cc6cc7ce63a0a3023fc99e341b94431d405a57"
   integrity sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==
-
-unified@^6.1.6:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/unified/-/unified-6.2.0.tgz#7fbd630f719126d67d40c644b7e3f617035f6dba"
-  integrity sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==
-  dependencies:
-    bail "^1.0.0"
-    extend "^3.0.0"
-    is-plain-obj "^1.1.0"
-    trough "^1.0.0"
-    vfile "^2.0.0"
-    x-is-string "^0.1.0"
 
 union-value@^1.0.0:
   version "1.0.1"
@@ -10177,37 +10001,6 @@ unique-slug@^2.0.0:
   dependencies:
     imurmurhash "^0.1.4"
 
-unist-util-is@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-3.0.0.tgz#d9e84381c2468e82629e4a5be9d7d05a2dd324cd"
-  integrity sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==
-
-unist-util-remove-position@^1.0.0:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz#ec037348b6102c897703eee6d0294ca4755a2020"
-  integrity sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==
-  dependencies:
-    unist-util-visit "^1.1.0"
-
-unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz#3f37fcf351279dcbca7480ab5889bb8a832ee1c6"
-  integrity sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==
-
-unist-util-visit-parents@^2.0.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz#25e43e55312166f3348cae6743588781d112c1e9"
-  integrity sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==
-  dependencies:
-    unist-util-is "^3.0.0"
-
-unist-util-visit@^1.1.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.1.tgz#4724aaa8486e6ee6e26d7ff3c8685960d560b1e3"
-  integrity sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==
-  dependencies:
-    unist-util-visit-parents "^2.0.0"
-
 universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
@@ -10235,11 +10028,6 @@ upath@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
-
-update-section@^0.3.0:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/update-section/-/update-section-0.3.3.tgz#458f17820d37820dc60e20b86d94391b00123158"
-  integrity sha1-RY8Xgg03gg3GDiC4bZQ5GwASMVg=
 
 upper-case@^1.1.1:
   version "1.1.3"
@@ -10356,28 +10144,6 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
-
-vfile-location@^2.0.0:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.6.tgz#8a274f39411b8719ea5728802e10d9e0dff1519e"
-  integrity sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==
-
-vfile-message@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-1.1.1.tgz#5833ae078a1dfa2d96e9647886cd32993ab313e1"
-  integrity sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==
-  dependencies:
-    unist-util-stringify-position "^1.1.1"
-
-vfile@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/vfile/-/vfile-2.3.0.tgz#e62d8e72b20e83c324bc6c67278ee272488bf84a"
-  integrity sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==
-  dependencies:
-    is-buffer "^1.1.4"
-    replace-ext "1.0.0"
-    unist-util-stringify-position "^1.0.0"
-    vfile-message "^1.0.0"
 
 vm-browserify@^1.0.1:
   version "1.1.2"
@@ -10627,11 +10393,6 @@ ws@^5.2.0:
   integrity sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==
   dependencies:
     async-limiter "~1.0.0"
-
-x-is-string@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
-  integrity sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=
 
 xml-name-validator@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
### Summary & motivation
Make it easier to access Stripe throughout you app.

* Add `useStripe` which injects the Stripe object passed to `<Elements>` into any component in the `<Elements>` tree.
* Modify the callback arguments of `<ElementsConsumer>` to inject both Stripe and Elements as an object.
* Disallow passing `undefined` to the `stripe` prop of `<Elements>`

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->


### Testing & documentation

I wrote unit tests.

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
