### PR TITLE
store Elements type on Element component

### DIFF
--- a/src/components/createElementComponent.js
+++ b/src/components/createElementComponent.js
@@ -149,6 +149,7 @@ const createElementComponent = (type: string) => {
   };
 
   Element.displayName = displayName;
+  Element.__elementType = type; // eslint-disable-line no-underscore-dangle
 
   return Element;
 };

--- a/src/components/createElementComponent.test.js
+++ b/src/components/createElementComponent.test.js
@@ -50,6 +50,10 @@ describe('createElementComponent', () => {
     expect(CardElement.displayName).toBe('CardElement');
   });
 
+  it('stores the element component`s type as a static property', () => {
+    expect(CardElement.__elementType).toBe('card'); // eslint-disable-line no-underscore-dangle
+  });
+
   it('passes id to the wrapping DOM element', () => {
     const wrapper = mount(
       <Elements stripe={stripe}>


### PR DESCRIPTION
### Summary & motivation

Add the Element component's type as a static property. This will eventually be used in the Stripe.js core library to enable passing an Element component to `elements.getElement`.

```js
const cardElement = elements.getElement(CardElement);
```

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

### Testing & documentation
I wrote a unit test.

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
