### PR TITLE
move elements consumer null

### DIFF
--- a/examples/class-components/0-Card-Minimal.js
+++ b/examples/class-components/0-Card-Minimal.js
@@ -4,10 +4,18 @@ import React from 'react';
 import {CardElement, Elements, ElementsConsumer} from '../../src';
 import '../styles/common.css';
 
-const stripe = window.Stripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
-
 class MyCheckoutForm extends React.Component {
-  createPaymentMethod = async (cardElement) => {
+  handleSubmit = async (event) => {
+    // Block native form submission.
+    event.preventDefault();
+
+    const {stripe, elements} = this.props;
+
+    // Get a reference to a mounted CardElement. Elements knows how
+    // to find your CardElement because there can only ever be one of
+    // each type of element.
+    const cardElement = elements.getElement(CardElement);
+
     const {error, paymentMethod} = await stripe.createPaymentMethod({
       type: 'card',
       card: cardElement,
@@ -22,49 +30,45 @@ class MyCheckoutForm extends React.Component {
 
   render() {
     return (
-      <ElementsConsumer>
-        {(elements) => (
-          <form
-            onSubmit={(event) => {
-              // block native form submission
-              event.preventDefault();
-
-              // Get a reference to a mounted CardElement. Elements knows how
-              // to find your CardElement because there can only ever be one of
-              // each type of element.
-              const cardElement = elements.getElement('card');
-
-              this.createPaymentMethod(cardElement);
-            }}
-          >
-            <CardElement
-              options={{
-                style: {
-                  base: {
-                    fontSize: '16px',
-                    color: '#424770',
-                    '::placeholder': {
-                      color: '#aab7c4',
-                    },
-                  },
-                  invalid: {
-                    color: '#9e2146',
-                  },
+      <form onSubmit={this.handleSubmit}>
+        <CardElement
+          options={{
+            style: {
+              base: {
+                fontSize: '16px',
+                color: '#424770',
+                '::placeholder': {
+                  color: '#aab7c4',
                 },
-              }}
-            />
-            <button type="submit">Pay</button>
-          </form>
-        )}
-      </ElementsConsumer>
+              },
+              invalid: {
+                color: '#9e2146',
+              },
+            },
+          }}
+        />
+        <button type="submit">Pay</button>
+      </form>
     );
   }
 }
 
+const InjectedCheckoutForm = () => {
+  return (
+    <ElementsConsumer>
+      {({elements, stripe}) => (
+        <MyCheckoutForm elements={elements} stripe={stripe} />
+      )}
+    </ElementsConsumer>
+  );
+};
+
+const stripe = window.Stripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
+
 const App = () => {
   return (
     <Elements stripe={stripe}>
-      <MyCheckoutForm />
+      <InjectedCheckoutForm />
     </Elements>
   );
 };

--- a/examples/class-components/1-Card-Async.js
+++ b/examples/class-components/1-Card-Async.js
@@ -6,8 +6,23 @@ import {CardElement, Elements, ElementsConsumer} from '../../src';
 import '../styles/common.css';
 
 class MyCheckoutForm extends React.Component {
-  createPaymentMethod = async (cardElement) => {
-    const {error, paymentMethod} = this.props.stripe.createPaymentMethod({
+  handleSubmit = async (event) => {
+    // Block native form submission.
+    event.preventDefault();
+
+    const {stripe, elements} = this.props;
+
+    // If Stripe has not loaded do nothing.
+    if (!stripe || !elements) {
+      return;
+    }
+
+    // Get a reference to a mounted CardElement. Elements knows how
+    // to find your CardElement because there can only ever be one of
+    // each type of element.
+    const cardElement = elements.getElement(CardElement);
+
+    const {error, paymentMethod} = await stripe.createPaymentMethod({
       type: 'card',
       card: cardElement,
     });
@@ -21,44 +36,38 @@ class MyCheckoutForm extends React.Component {
 
   render() {
     return (
-      <ElementsConsumer>
-        {(elements) => (
-          <form
-            onSubmit={(event) => {
-              // block native form submission
-              event.preventDefault();
-
-              // Get a reference to a mounted CardElement. Elements will know how
-              // to find your CardElement since there can only ever be one of
-              // each type of element.
-              const cardElement = elements.getElement('card');
-
-              this.createPaymentMethod(cardElement);
-            }}
-          >
-            <CardElement
-              options={{
-                style: {
-                  base: {
-                    fontSize: '16px',
-                    color: '#424770',
-                    '::placeholder': {
-                      color: '#aab7c4',
-                    },
-                  },
-                  invalid: {
-                    color: '#9e2146',
-                  },
+      <form onSubmit={this.handleSubmit}>
+        <CardElement
+          options={{
+            style: {
+              base: {
+                fontSize: '16px',
+                color: '#424770',
+                '::placeholder': {
+                  color: '#aab7c4',
                 },
-              }}
-            />
-            <button type="submit">Pay</button>
-          </form>
-        )}
-      </ElementsConsumer>
+              },
+              invalid: {
+                color: '#9e2146',
+              },
+            },
+          }}
+        />
+        <button type="submit">Pay</button>
+      </form>
     );
   }
 }
+
+const InjectedCheckoutForm = () => {
+  return (
+    <ElementsConsumer>
+      {({elements, stripe}) => (
+        <MyCheckoutForm elements={elements} stripe={stripe} />
+      )}
+    </ElementsConsumer>
+  );
+};
 
 class App extends React.Component {
   constructor(props) {
@@ -89,7 +98,7 @@ class App extends React.Component {
     const {stripe} = this.state;
     return (
       <Elements stripe={stripe}>
-        {stripe ? <MyCheckoutForm stripe={stripe} /> : null}
+        <InjectedCheckoutForm />
       </Elements>
     );
   }

--- a/examples/class-components/1-Card-Async.js
+++ b/examples/class-components/1-Card-Async.js
@@ -62,7 +62,7 @@ class MyCheckoutForm extends React.Component {
 const InjectedCheckoutForm = () => {
   return (
     <ElementsConsumer>
-      {({elements, stripe}) => (
+      {({stripe, elements}) => (
         <MyCheckoutForm elements={elements} stripe={stripe} />
       )}
     </ElementsConsumer>

--- a/examples/hooks/0-Card-Minimal.js
+++ b/examples/hooks/0-Card-Minimal.js
@@ -1,23 +1,22 @@
 // @noflow
 
 import React from 'react';
-import {CardElement, Elements, useElements} from '../../src';
+import {CardElement, Elements, useElements, useStripe} from '../../src';
 
 import '../styles/common.css';
 
-const stripe = window.Stripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
-
 const Checkout = () => {
+  const stripe = useStripe();
   const elements = useElements();
 
   const handleSubmit = async (event) => {
-    // block native form submission
+    // Block native form submission.
     event.preventDefault();
 
     // Get a reference to a mounted CardElement. Elements knows how
     // to find your CardElement because there can only ever be one of
     // each type of element.
-    const cardElement = elements.getElement('card');
+    const cardElement = elements.getElement(CardElement);
 
     // Use your card Element with other Stripe.js APIs
     const {error, paymentMethod} = await stripe.createPaymentMethod({
@@ -54,6 +53,8 @@ const Checkout = () => {
     </form>
   );
 };
+
+const stripe = window.Stripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
 
 const App = () => {
   return (

--- a/examples/hooks/0-Card-Minimal.js
+++ b/examples/hooks/0-Card-Minimal.js
@@ -5,7 +5,7 @@ import {CardElement, Elements, useElements, useStripe} from '../../src';
 
 import '../styles/common.css';
 
-const Checkout = () => {
+const MyCheckoutForm = () => {
   const stripe = useStripe();
   const elements = useElements();
 
@@ -59,7 +59,7 @@ const stripe = window.Stripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
 const App = () => {
   return (
     <Elements stripe={stripe}>
-      <Checkout />
+      <MyCheckoutForm />
     </Elements>
   );
 };

--- a/examples/hooks/0-Card-Minimal.js
+++ b/examples/hooks/0-Card-Minimal.js
@@ -13,6 +13,8 @@ const Checkout = () => {
     // Block native form submission.
     event.preventDefault();
 
+    console.log('here!');
+
     // Get a reference to a mounted CardElement. Elements knows how
     // to find your CardElement because there can only ever be one of
     // each type of element.

--- a/examples/hooks/0-Card-Minimal.js
+++ b/examples/hooks/0-Card-Minimal.js
@@ -13,8 +13,6 @@ const Checkout = () => {
     // Block native form submission.
     event.preventDefault();
 
-    console.log('here!');
-
     // Get a reference to a mounted CardElement. Elements knows how
     // to find your CardElement because there can only ever be one of
     // each type of element.

--- a/examples/hooks/1-Card-Async.js
+++ b/examples/hooks/1-Card-Async.js
@@ -1,20 +1,26 @@
 // @noflow
 
 import React, {useState, useEffect} from 'react';
-import {CardElement, Elements, useElements} from '../../src';
+import {CardElement, Elements, useElements, useStripe} from '../../src';
 import '../styles/common.css';
 
-const MyCheckoutForm = ({stripe}) => {
+const MyCheckoutForm = () => {
+  const stripe = useStripe();
   const elements = useElements();
 
   const handleSubmit = async (event) => {
-    // block native form submission
+    // Block native form submission.
     event.preventDefault();
+
+    // If Stripe has not loaded do nothing.
+    if (!stripe || !elements) {
+      return;
+    }
 
     // Get a reference to a mounted CardElement. Elements will know how
     // to find your CardElement since there can only ever be one of
     // each type of element.
-    const cardElement = elements.getElement('card');
+    const cardElement = elements.getElement(CardElement);
 
     // Use your card Element with other Stripe.js APIs
     const {error, paymentMethod} = stripe.createPaymentMethod({
@@ -47,7 +53,9 @@ const MyCheckoutForm = ({stripe}) => {
           },
         }}
       />
-      <button type="submit">Pay</button>
+      <button type="submit" disabled={!stripe}>
+        Pay
+      </button>
     </form>
   );
 };
@@ -75,7 +83,7 @@ const App = () => {
 
   return (
     <Elements stripe={stripe}>
-      {stripe ? <MyCheckoutForm stripe={stripe} /> : null}
+      <MyCheckoutForm />
     </Elements>
   );
 };

--- a/examples/hooks/2-Card-Detailed.js
+++ b/examples/hooks/2-Card-Detailed.js
@@ -1,10 +1,8 @@
 // @noflow
 
 import React, {useState} from 'react';
-import {CardElement, Elements, useElements} from '../../src';
+import {CardElement, Elements, useElements, useStripe} from '../../src';
 import '../styles/2-Card-Detailed.css';
-
-const stripe = window.Stripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
 
 const CARD_OPTIONS = {
   iconStyle: 'solid',
@@ -101,6 +99,7 @@ const ResetButton = ({onClick}) => (
 );
 
 const Checkout = () => {
+  const stripe = useStripe();
   const elements = useElements();
   const [error, setError] = useState(null);
   const [cardComplete, setCardComplete] = useState(false);
@@ -126,7 +125,7 @@ const Checkout = () => {
 
     const payload = await stripe.createPaymentMethod({
       type: 'card',
-      card: elements.getElement('card'),
+      card: elements.getElement(CardElement),
       billing_details: billingDetails,
     });
 
@@ -224,6 +223,8 @@ const ELEMENTS_OPTIONS = {
     },
   ],
 };
+
+const stripe = window.Stripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
 
 const App = () => {
   return (

--- a/examples/hooks/3-Split-Card.js
+++ b/examples/hooks/3-Split-Card.js
@@ -7,12 +7,11 @@ import {
   CardExpiryElement,
   Elements,
   useElements,
+  useStripe,
 } from '../../src';
 
 import {logEvent, Result, ErrorResult} from '../util';
 import '../styles/common.css';
-
-const stripe = window.Stripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
 
 const ELEMENT_OPTIONS = {
   style: {
@@ -32,6 +31,7 @@ const ELEMENT_OPTIONS = {
 
 const Checkout = () => {
   const elements = useElements();
+  const stripe = useStripe();
   const [name, setName] = useState('');
   const [postal, setPostal] = useState('');
   const [result, setResult] = useState(null);
@@ -39,7 +39,7 @@ const Checkout = () => {
   const handleSubmit = async (ev) => {
     ev.preventDefault();
 
-    const cardElement = elements.getElement('cardNumber');
+    const cardElement = elements.getElement(CardNumberElement);
 
     const payload = await stripe.createPaymentMethod({
       type: 'card',
@@ -113,6 +113,8 @@ const Checkout = () => {
     </form>
   );
 };
+
+const stripe = window.Stripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
 
 const App = () => {
   return (

--- a/examples/hooks/4-Payment-Request-Button.js
+++ b/examples/hooks/4-Payment-Request-Button.js
@@ -1,12 +1,10 @@
 // @noflow
 
 import React, {useState, useEffect} from 'react';
-import {PaymentRequestButtonElement, Elements} from '../../src';
+import {PaymentRequestButtonElement, Elements, useStripe} from '../../src';
 
 import {Result, ErrorResult} from '../util';
 import '../styles/common.css';
-
-const stripe = window.Stripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
 
 const NotAvailableResult = () => (
   <Result>
@@ -35,6 +33,7 @@ const ELEMENT_OPTIONS = {
 };
 
 const Checkout = () => {
+  const stripe = useStripe();
   const [paymentRequest, setPaymentRequest] = useState(null);
   const [result, setResult] = useState(null);
 
@@ -87,6 +86,8 @@ const Checkout = () => {
     </form>
   );
 };
+
+const stripe = window.Stripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
 
 const App = () => {
   return (

--- a/examples/hooks/5-IBAN.js
+++ b/examples/hooks/5-IBAN.js
@@ -1,12 +1,10 @@
 // @noflow
 
 import React, {useState} from 'react';
-import {IbanElement, Elements, useElements} from '../../src';
+import {IbanElement, Elements, useElements, useStripe} from '../../src';
 
 import {logEvent, Result, ErrorResult} from '../util';
 import '../styles/common.css';
-
-const stripe = window.Stripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
 
 const ELEMENT_OPTIONS = {
   supportedCountries: ['SEPA'],
@@ -26,6 +24,7 @@ const ELEMENT_OPTIONS = {
 };
 
 const Checkout = () => {
+  const stripe = useStripe();
   const elements = useElements();
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
@@ -34,7 +33,7 @@ const Checkout = () => {
   const handleSubmit = async (ev) => {
     ev.preventDefault();
 
-    const ibanElement = elements.getElement('iban');
+    const ibanElement = elements.getElement(IbanElement);
 
     const payload = await stripe.createPaymentMethod({
       type: 'sepa_debit',
@@ -89,6 +88,8 @@ const Checkout = () => {
     </form>
   );
 };
+
+const stripe = window.Stripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
 
 const App = () => {
   return (

--- a/examples/hooks/6-iDEAL.js
+++ b/examples/hooks/6-iDEAL.js
@@ -1,12 +1,10 @@
 // @noflow
 
 import React, {useState} from 'react';
-import {IdealBankElement, Elements, useElements} from '../../src';
+import {IdealBankElement, Elements, useElements, useStripe} from '../../src';
 
 import {logEvent, Result, ErrorResult} from '../util';
 import '../styles/common.css';
-
-const stripe = window.Stripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
 
 const ELEMENT_OPTIONS = {
   classes: {
@@ -30,6 +28,7 @@ const ELEMENT_OPTIONS = {
 };
 
 const Checkout = () => {
+  const stripe = useStripe();
   const elements = useElements();
   const [name, setName] = useState('');
   const [result, setResult] = useState(null);
@@ -37,7 +36,7 @@ const Checkout = () => {
   const handleSubmit = async (ev) => {
     ev.preventDefault();
 
-    const idealBankElement = elements.getElement('idealBank');
+    const idealBankElement = elements.getElement(IdealBankElement);
 
     const payload = await stripe.createPaymentMethod({
       type: 'ideal',
@@ -81,6 +80,8 @@ const Checkout = () => {
     </form>
   );
 };
+
+const stripe = window.Stripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
 
 const App = () => {
   return (

--- a/src/components/Elements.js
+++ b/src/components/Elements.js
@@ -36,7 +36,7 @@ export const createElementsContext = (
 export const parseElementsContext = (
   ctx: ?ElementContext,
   useCase: string
-): {|elements: ElementsShape, stripe: StripeShape|} | null => {
+): {|elements: ElementsShape | null, stripe: StripeShape | null|} => {
   if (!ctx) {
     throw new Error(
       `Could not find Elements context; You need to wrap the part of your app that ${useCase} in an <Elements> provider.`
@@ -44,7 +44,7 @@ export const parseElementsContext = (
   }
 
   if (ctx.tag === 'loading') {
-    return null;
+    return {stripe: null, elements: null};
   }
 
   const {stripe, elements} = ctx;
@@ -129,23 +129,24 @@ export const useElementsContextWithUseCase = (useCaseMessage: string) => {
 };
 
 export const useElements = (): ElementsShape | null => {
-  const ctx = useElementsContextWithUseCase('calls useElements()');
+  const {elements} = useElementsContextWithUseCase('calls useElements()');
 
-  return ctx && ctx.elements;
+  return elements;
 };
 
 export const useStripe = (): StripeShape | null => {
-  const ctx = useElementsContextWithUseCase('calls useStripe()');
+  const {stripe} = useElementsContextWithUseCase('calls useStripe()');
 
-  return ctx && ctx.stripe;
+  return stripe;
 };
 
 export const ElementsConsumer = ({
   children,
 }: {|
-  children: (
-    elements: {|elements: ElementsShape, stripe: StripeShape|} | null
-  ) => React$Node,
+  children: ({|
+    elements: ElementsShape | null,
+    stripe: StripeShape | null,
+  |}) => React$Node,
 |}) => {
   const ctx = useElementsContextWithUseCase('mounts <ElementsConsumer>');
   return children(ctx);

--- a/src/components/createElementComponent.js
+++ b/src/components/createElementComponent.js
@@ -57,7 +57,7 @@ const createElementComponent = (type: string) => {
       onClick,
     } = props;
 
-    const ctx = useElementsContextWithUseCase(`mounts <${displayName}>`);
+    const {elements} = useElementsContextWithUseCase(`mounts <${displayName}>`);
     const elementRef = useRef();
     const domNode = useRef();
 
@@ -68,12 +68,8 @@ const createElementComponent = (type: string) => {
     const callOnChange = callbackReference(onChange);
 
     useLayoutEffect(() => {
-      if (
-        elementRef.current == null &&
-        ctx != null &&
-        domNode.current != null
-      ) {
-        const element = ctx.elements.create(type, options);
+      if (elementRef.current == null && elements && domNode.current != null) {
+        const element = elements.create(type, options);
         elementRef.current = element;
         element.mount(domNode.current);
         element.on('ready', () => callOnReady(element));

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,13 @@
 // @flow
 import createElementComponent from './components/createElementComponent';
-import {useElements, Elements, ElementsConsumer} from './components/Elements';
+import {
+  useElements,
+  useStripe,
+  Elements,
+  ElementsConsumer,
+} from './components/Elements';
 
-export {Elements, useElements, ElementsConsumer};
+export {Elements, useElements, useStripe, ElementsConsumer};
 export const CardElement = createElementComponent('card');
 export const CardNumberElement = createElementComponent('cardNumber');
 export const CardExpiryElement = createElementComponent('cardExpiry');


### PR DESCRIPTION
### Summary & motivation
Before Stripe.js loads, ElementsConsumer should be called with an object with null values rather with null. This better mirrors the useElements and useStripe hooks and it gets around this kind of awkwardness:

```js
const InjectedCheckoutForm = () => {
  return (
    <ElementsConsumer>
      {(stuff) => (
        <MyCheckoutForm elements={stuff && stuff.elements} stripe={stuff && stuff.stripe} />
      )}
    </ElementsConsumer>
  );
};
```

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

Copy [this template] **or** link to an API review issue.

[this template]:
  https://github.com/stripe/react-stripe/tree/master/.github/API_REVIEW.md

### Testing & documentation
Lots of example updates, existing tests
<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
