### PR TITLE
Enable eslint-plugin-react-hooks, fix violations

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -11,10 +11,13 @@ parser: 'babel-eslint'
 plugins:
   - flowtype
   - jest
+  - react-hooks
 env:
   jest/globals: true
   browser: true
 rules:
+  react-hooks/rules-of-hooks: 2
+  react-hooks/exhaustive-deps: 1
   react/jsx-filename-extension: 0
   react/jsx-props-no-spreading: 0
   no-duplicate-imports: 2 # doesn't support flow imports.

--- a/examples/hooks/4-Payment-Request-Button.js
+++ b/examples/hooks/4-Payment-Request-Button.js
@@ -59,7 +59,7 @@ const Checkout = () => {
         setResult(<NotAvailableResult />);
       }
     });
-  }, []);
+  }, [stripe]);
 
   return (
     <form>

--- a/src/components/createElementComponent.js
+++ b/src/components/createElementComponent.js
@@ -28,7 +28,7 @@ const extractUpdateableOptions = (options: ?MixedObject) => {
 
 const noop = () => {};
 const capitalized = (str: string) => str.charAt(0).toUpperCase() + str.slice(1);
-const callbackReference = (cb: MixedFunction) => {
+const useCallbackReference = (cb: MixedFunction) => {
   const cbStore = useRef(cb);
 
   useEffect(() => {
@@ -61,11 +61,11 @@ const createElementComponent = (type: string) => {
     const elementRef = useRef();
     const domNode = useRef();
 
-    const callOnReady = callbackReference(onReady);
-    const callOnBlur = callbackReference(onBlur);
-    const callOnFocus = callbackReference(onFocus);
-    const callOnClick = callbackReference(onClick);
-    const callOnChange = callbackReference(onChange);
+    const callOnReady = useCallbackReference(onReady);
+    const callOnBlur = useCallbackReference(onBlur);
+    const callOnFocus = useCallbackReference(onFocus);
+    const callOnClick = useCallbackReference(onClick);
+    const callOnChange = useCallbackReference(onChange);
 
     useLayoutEffect(() => {
       if (elementRef.current == null && elements && domNode.current != null) {


### PR DESCRIPTION
### Summary & motivation

Poking around I noticed that `eslint-plugin-react-hooks` was already a dependency, but it wasn't enabled. This is an important plugin when using React Hooks as it prevents potentially undefined behavior.

This enables `eslint-plugin-react-hooks` making `rules-of-hooks` and error and `exhaustive-deps` a warning, and also fixes any existing violations uncovered.

### Testing & documentation

* `yarn build` runs successfully