### PR TITLE
Disable require-default-props lint rule

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -17,6 +17,7 @@ env:
 rules:
   react/jsx-filename-extension: 0
   react/jsx-props-no-spreading: 0
+  react/require-default-props: 0
   no-duplicate-imports: 2 # doesn't support flow imports.
   no-console: 0
   func-style: 2

--- a/src/components/Elements.js
+++ b/src/components/Elements.js
@@ -1,5 +1,5 @@
 // @flow
-/* eslint-disable react/forbid-prop-types, react/require-default-props */
+/* eslint-disable react/forbid-prop-types */
 import React, {useContext, useMemo, useState} from 'react';
 import PropTypes from 'prop-types';
 

--- a/src/components/createElementComponent.js
+++ b/src/components/createElementComponent.js
@@ -134,8 +134,6 @@ const createElementComponent = (type: string) => {
   };
 
   Element.defaultProps = {
-    id: undefined,
-    className: undefined,
     onChange: noop,
     onBlur: noop,
     onFocus: noop,


### PR DESCRIPTION
### Summary & motivation

The require-default-props lint rule was being overly restrictive for this use case. There is no good reason to include a value in `defaultProps` if it is truly optional, as that just means that React now has to do the work to merge this `undefined` value into props for no reason.

I'd argue that you should just avoid `defaultProps` all together and use destructuring with default values, but that's maybe more personal preference.

### Testing & documentation

`yarn build` completes successfully